### PR TITLE
Split out VTF document functionality from the main viewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if (BUILD_GUI)
 	set(VIEWER_SRC
 			src/gui/main.cpp
 			src/gui/viewer.cpp
+			src/gui/document.cpp
 			res/resource.qrc)
 			
 	add_executable(vtfview ${VIEWER_SRC})

--- a/src/gui/document.cpp
+++ b/src/gui/document.cpp
@@ -1,0 +1,94 @@
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+#include "document.hpp"
+#include "common/util.hpp"
+
+using namespace vtfview;
+
+Document::Document(QObject* parent)
+	: QObject(parent) {
+}
+
+void Document::new_file() {
+	unload_file();
+}
+
+void Document::reload_file() {
+	auto oldPath = path_;
+	unload_file();
+	load_file(oldPath.c_str());
+}
+
+void Document::mark_modified() {
+	dirty_ = true;
+	emit vtfFileModified(true);
+}
+
+void Document::unmark_modified() {
+	dirty_ = false;
+	emit vtfFileModified(false);
+}
+
+bool Document::save(const std::string& path) {
+	if (!dirty_)
+		return true;
+	dirty_ = false;
+
+	if (!file_->Save(path.empty() ? path_.c_str() : path.c_str())) {
+		return false;
+	}
+
+	unmark_modified();
+	emit vtfFileModified(false);
+	return true;
+}
+
+bool Document::load_file(const char* path) {
+	std::uint8_t* buffer;
+	auto numRead = util::read_file(path, buffer);
+	if (!numRead)
+		return false;
+
+	bool ok = load_file_internal(buffer, numRead);
+	delete buffer;
+
+	path_ = path;
+	emit vtfFileChanged(path_, file_);
+	return ok;
+}
+
+bool Document::load_file(const void* data, size_t size) {
+	if (!load_file_internal(data, size))
+		return false;
+	emit vtfFileChanged("", file_);
+	return true;
+}
+
+bool Document::load_file(VTFLib::CVTFFile* file) {
+	emit vtfFileChanged("", file);
+	file_ = file;
+	path_ = "";
+	return true;
+}
+
+void Document::unload_file() {
+	if (!file_)
+		return;
+	emit vtfFileChanged("", nullptr);
+	delete file_;
+	file_ = nullptr;
+	path_ = "";
+	unmark_modified();
+}
+
+bool Document::load_file_internal(const void* data, size_t size) {
+	file_ = new VTFLib::CVTFFile();
+	if (!file_->Load(data, size)) {
+		delete file_;
+		file_ = nullptr;
+		return false;
+	}
+	return true;
+}

--- a/src/gui/document.hpp
+++ b/src/gui/document.hpp
@@ -1,0 +1,74 @@
+
+#pragma once
+
+#include <QObject>
+
+#include "VTFLib.h"
+
+namespace vtfview
+{
+
+	/**
+	 * Represents a VTF file document
+	 * Handles saving, loading, etc
+	 */
+	class Document : public QObject {
+		Q_OBJECT;
+
+	public:
+		Document(QObject* parent);
+
+		bool load_file(const char* path);
+		bool load_file(const void* data, size_t size);
+		bool load_file(VTFLib::CVTFFile* file);
+		void unload_file();
+
+		inline auto* file() {
+			return file_;
+		}
+		inline const auto* file() const {
+			return file_;
+		}
+
+		void mark_modified();
+		void unmark_modified();
+
+		bool save(const std::string& path = "");
+		void new_file();
+		void reload_file();
+
+		const std::string& path() const {
+			return path_;
+		}
+		void set_path(const std::string& p) {
+			path_ = p;
+		}
+
+		bool dirty() const {
+			return dirty_;
+		}
+
+	signals:
+		/**
+		 * Invoked whenever the vtf changes
+		 * file may be nullptr if the file is fully unloaded
+		 * path may be empty if this file is not loaded from disk
+		 */
+		void vtfFileChanged(const std::string& path, VTFLib::CVTFFile* file);
+
+		/**
+		 * Invoked when the modification state of the VTF changed
+		 * @param modified True if file is modified, false if not
+		 */
+		void vtfFileModified(bool modified);
+
+	protected:
+		bool load_file_internal(const void* bytes, size_t size);
+
+	private:
+		VTFLib::CVTFFile* file_ = nullptr;
+		bool dirty_ = false;
+		std::string path_;
+	};
+
+} // namespace vtfview

--- a/src/gui/viewer.hpp
+++ b/src/gui/viewer.hpp
@@ -9,10 +9,13 @@
 
 #include "VTFLib.h"
 
+#include "document.hpp"
+
 #pragma once
 
 class QSpinBox;
 class QCheckBox;
+class QComboBox;
 
 namespace vtfview
 {
@@ -27,46 +30,37 @@ namespace vtfview
 	public:
 		ViewerMainWindow(QWidget* pParent = nullptr);
 
-		bool load_file(const char* path);
-		bool load_file(const void* data, size_t size);
-		bool load_file(VTFLib::CVTFFile* file);
-		void unload_file();
-
-		inline auto* file() {
-			return file_;
+		inline auto* document() {
+			return doc_;
 		}
-		inline const auto* file() const {
-			return file_;
+		inline const auto* document() const {
+			return doc_;
 		}
-
-		void mark_modified();
-		void unmark_modified();
 
 		void save(bool saveAs = false);
 		void open_file();
 		void new_file();
 		void reload_file();
 
+		bool load_file(const char* path) {
+			return document()->load_file(path);
+		}
+
 	protected:
 		void setup_ui();
 		void setup_menubar();
 		void reset_state();
-		bool ask_save();
 
 		void closeEvent(QCloseEvent* event) override;
 
-	signals:
-		/**
-		 * Invoked whenever the vtf changes
-		 * file may be nullptr if the file is fully unloaded
-		 */
-		void vtfFileChanged(VTFLib::CVTFFile* file);
+		void mark_modified();
+		void unmark_modified();
+
+		bool ask_save();
 
 	private:
-		VTFLib::CVTFFile* file_ = nullptr;
-		bool dirty_ = false;
-		std::string path_;
 		ImageViewWidget* viewer_ = nullptr;
+		Document* doc_ = nullptr;
 	};
 
 	/**
@@ -90,6 +84,7 @@ namespace vtfview
 		}
 
 		std::unordered_map<std::string, QLineEdit*> fields_;
+		QComboBox* formatCombo_ = nullptr;
 	};
 
 	/**


### PR DESCRIPTION
Before this, everything was combined and kinda crappy as a result. This cleans things up a bit.

Also added a combo box for the image format. Doesn't do anything when the selection is changed (yet). 