### PR TITLE
fix: Prevent vector out of range crash on some systems

### DIFF
--- a/src/gui/viewer.cpp
+++ b/src/gui/viewer.cpp
@@ -123,7 +123,7 @@ void ViewerMainWindow::setup_ui() {
 	setup_menubar();
 
 	// Register global actions
-	shortcuts_.reserve(Action_Count);
+	shortcuts_.resize(Action_Count);
 	auto* saveShortcut = new QShortcut(
 		QKeySequence::Save, this,
 		[this]


### PR DESCRIPTION
Miniscule issue, but this line was preventing me from running vtfview on my system, since reserve() doesn't actually create elements, and operator[] can require the element to exist.