### PR TITLE
Compression support + readme/docs rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,104 @@
 
 vtex2 is a Valve Texture Format conversion and creation tool. It has a CLI and a GUI component for viewing, packing and otherwise converting the files.
 
+## Usage
+
+Command help documentation and usage examples can be shown on the command line using `vtex2 --help`.
+
+For action-specific help, use `vtex2 <action> --help`.
+
+### Creating VTFs
+
+Creating a VTF can be done with the `vtex2 convert` action.
+
+For example, the following command will create a VTF called `some-file.vtf` with the format `BGRA8888`:
+```
+vtex2 convert -f bgra8888 some-file.jpg
+```
+
+If you pass a directory to `vtex2 convert`, it will convert all files in that directory. The `-r` or `--recursive` parameter
+will cause the program to descend and process subdirectories too.
+
+Full list of options:
+```
+USAGE: vtex2 convert [OPTIONS] file...
+
+  Convert a generic image file to VTF
+
+Options:
+  --bumpscale          Bumpscale
+  --clamps             Clamp on S axis
+  --clampt             Clamp on T axis
+  --clampu             Clamp on U axis
+  --gamma-correct      Apply gamma correction
+  --pointsample        Set point sampling method
+  --srgb               Process this image in sRGB color space
+  --start-frame        Animation frame to start on
+  --thumbnail          Generate thumbnail for the image
+  --trilinear          Set trilinear sampling method
+  --version            Set the VTF version to use
+  -c,--compress [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+                       DEFLATE compression level to use. 0=none, 9=max. This will force VTF version to 7.6
+  -f,--format [rgba8888, abgr8888, rgb888, bgr888, rgb565, i8, ia88, p8, a8, rgb888_bluescreen, bgr888_bluescreen, argb8888, bgra8888, dxt1, dxt3, dxt5, bgrx8888, bgr565, bgrx5551, bgra4444, dxt1_onebitalpha, bgra5551, uv88, uvwq8888, rgba16161616f, rgba16161616, uvlx8888, r32f, rgb323232f, rgba32323232f, ati2n, ati1n]
+                       Image format of the VTF
+  -m,--mips            Number of mips to generate
+  -n,--normal          Create a normal map
+  -o,--output          Name of the output VTF
+  -r,--recursive       Recursively process directories
+  file                 Image file to convert
+```
+
+### Extracting image data from VTF
+
+Extracting image data from a VTF can be done using `vtex2 extract`.
+
+For example, the following command will extract the VTF to `some-file.jpg`:
+```
+vtex2 extract -f jpg some-file.vtf
+```
+
+If you pass a directory to `vtex2 extract`, it will convert all files in that directory. The `-r` or `--recursive` parameter
+will cause the program to descend and process subdirectories too.
+
+Full list of options:
+```
+USAGE: vtex2 extract [OPTIONS] file...
+
+  Converts a VTF into png, tga, jpeg, bmp or hdr image file
+
+Options:
+  -f,--format [png, jpeg, jpg, tga, bmp, hdr]
+                       Output format to use
+  -m,--mip             Mipmap to extract from image
+  -na,--no-alpha       Exclude alpha channel from converted image
+  -o,--output          File to place the output in
+  -r,--recursive       Recursively process directories
+  file                 VTF file to convert
+```
+
+### Displaying VTF Info
+
+The `vtex2 info` command can be used to display some info about VTF files.
+
+Full list of options:
+```
+USAGE: vtex2 info [OPTIONS] file...
+
+  Displays info about a VTF file
+
+Options:
+  -a,--all             Display all detailed info about a VTF
+  -r,--resources       List all resource entries in the VTF
+  file                 VTF file to process
+```
+
 ## Building 
+
+The first step is to clone the repository. Make sure to do a recursive clone!
+
+```
+git clone https://github.com/ChaosInitiative/vtex2.git --recursive
+```
 
 ### Linux
 
@@ -12,7 +109,6 @@ Required packages:
 * make or ninja
 
 ```sh
-git submodule update --init --recursive
 mkdir build && cd build
 cmake ..
 make -j$(nproc)

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -114,61 +114,6 @@ const OptionList& ActionConvert::get_options() const {
 				.value(false)
 				.help("Recursively process directories"));
 
-		opts::normal = opts.add(
-			ActionOption()
-				.short_opt("-n")
-				.long_opt("--normal")
-				.type(OptType::Bool)
-				.value(false)
-				.help("Create a normal map"));
-
-		opts::clamps =
-			opts.add(ActionOption().long_opt("--clamps").type(OptType::Bool).value(false).help("Clamp on S axis"));
-
-		opts::clampt =
-			opts.add(ActionOption().long_opt("--clampt").type(OptType::Bool).value(false).help("Clamp on T axis"));
-
-		opts::clampu =
-			opts.add(ActionOption().long_opt("--clampu").type(OptType::Bool).value(false).help("Clamp on U axis"));
-
-		opts::pointsample = opts.add(
-			ActionOption()
-				.long_opt("--pointsample")
-				.type(OptType::Bool)
-				.value(false)
-				.help("Set point sampling method"));
-
-		opts::trilinear = opts.add(
-			ActionOption()
-				.long_opt("--trilinear")
-				.type(OptType::Bool)
-				.value(false)
-				.help("Set trilinear sampling method"));
-
-		opts::mips = opts.add(
-			ActionOption()
-				.short_opt("-m")
-				.long_opt("--mips")
-				.type(OptType::Int)
-				.value(10)
-				.help("Number of mips to generate"));
-
-		opts::startframe = opts.add(
-			ActionOption().long_opt("--start-frame").type(OptType::Int).value(0).help("Animation frame to start on"));
-
-		opts::bumpscale =
-			opts.add(ActionOption().long_opt("--bumpscale").type(OptType::Float).value(0).help("Bumpscale"));
-
-		opts::gammacorrect = opts.add(
-			ActionOption().long_opt("--gamma-correct").type(OptType::Float).value(0).help("Apply gamma correction"));
-
-		opts::srgb = opts.add(
-			ActionOption()
-				.long_opt("--srgb")
-				.type(OptType::Bool)
-				.value(false)
-				.help("Process this image in sRGB color space"));
-
 		opts::thumbnail = opts.add(
 			ActionOption()
 				.long_opt("--thumbnail")
@@ -230,13 +175,6 @@ const OptionList& ActionConvert::get_options() const {
 				.type(OptType::Bool)
 				.value(false)
 				.help("Process this image in sRGB color space"));
-
-		opts::thumbnail = opts.add(
-			ActionOption()
-				.long_opt("--thumbnail")
-				.type(OptType::Bool)
-				.value(false)
-				.help("Generate thumbnail for the image"));
 
 		opts::version = opts.add(
 			ActionOption().long_opt("--version").type(OptType::String).value("7.5").help("Set the VTF version to use"));

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -36,8 +36,6 @@ namespace opts
 	static int thumbnail;
 } // namespace opts
 
-static VTFImageFormat format_for_image(const imglib::ImageInfo_t& info);
-
 std::string ActionConvert::get_help() const {
 	return "Convert a generic image file to VTF";
 }
@@ -348,7 +346,7 @@ bool ActionConvert::add_image_data(
 			imglib::image_end(image);
 		});
 
-	auto dataFormat = format_for_image(data.info);
+	auto dataFormat = imglib::get_vtf_format(data.info);
 	vlByte* dest = nullptr;
 	// Convert to requested format, if possible.
 	if (format != IMAGE_FORMAT_NONE) {
@@ -376,18 +374,4 @@ bool ActionConvert::add_image_data(
 
 	free(dest);
 	return true;
-}
-
-// Determine the VTF format we want to use for the image
-static VTFImageFormat format_for_image(const imglib::ImageInfo_t& info) {
-	if (info.comps == 3) {
-		if (info.type == imglib::Float)
-			return IMAGE_FORMAT_RGB323232F;
-		return info.type == imglib::UInt8 ? IMAGE_FORMAT_RGB888 : IMAGE_FORMAT_RGBA16161616;
-	}
-	else {
-		if (info.type == imglib::Float)
-			return IMAGE_FORMAT_RGBA32323232F;
-		return info.type == imglib::UInt8 ? IMAGE_FORMAT_RGBA8888 : IMAGE_FORMAT_RGBA16161616;
-	}
 }

--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -102,7 +102,7 @@ const OptionList& ActionConvert::get_options() const {
 				.metavar("file")
 				.type(OptType::String)
 				.value("")
-				.help("Image file to convert")
+				.help("Image file to convert or directory to process")
 				.required(true)
 				.end_of_line(true));
 

--- a/src/cli/action_extract.cpp
+++ b/src/cli/action_extract.cpp
@@ -190,7 +190,7 @@ bool ActionExtract::extract_file(
 			free(imageData);
 		});
 
-	// Only supported format for Hdr is 32-bit RGBA - everything else will be squashed down into RGB formats
+	// Only supported format for Hdr is 32-bit RGBA - everything else will be squashed down into 32 or 24bpp RGB/RGBA
 	bool destIsFloat = (targetFmt == imglib::Hdr);
 	bool ok = false;
 	if (destIsFloat) {

--- a/src/cli/action_extract.cpp
+++ b/src/cli/action_extract.cpp
@@ -54,7 +54,7 @@ const OptionList& ActionExtract::get_options() const {
 				.metavar("file")
 				.type(OptType::String)
 				.value("")
-				.help("VTF file to convert")
+				.help("VTF file to convert or directory to process")
 				.required(true)
 				.end_of_line(true));
 

--- a/src/cli/action_info.cpp
+++ b/src/cli/action_info.cpp
@@ -96,6 +96,10 @@ int ActionInfo::exec(const OptionList& opts) {
 		FMT_STRING("{} frame(s), {} face(s), {} mipmaps\n"), file_->GetFrameCount(), file_->GetFaceCount(),
 		file_->GetMipmapCount());
 
+	if (file_->GetMajorVersion() >= 7 && file_->GetMinorVersion() >= 6) {
+		fmt::print(FMT_STRING("DEFLATE compression level {}\n"), file_->GetAuxCompressionLevel());
+	}
+
 	if (details) {
 		vlUInt dataSize;
 		if (auto* crcPtr = file_->GetResourceData(VTF_RSRC_CRC, dataSize)) {
@@ -145,8 +149,12 @@ void ActionInfo::cleanup() {
 
 void ActionInfo::compact_info() {
 	fmt::print(
-		FMT_STRING("VTF {}.{}, {} x {} x {}, {} frames, {} mipmaps, {} faces, image format {}\n"),
+		FMT_STRING("VTF {}.{}, {} x {} x {}, {} frames, {} mipmaps, {} faces, image format {}"),
 		file_->GetMajorVersion(), file_->GetMinorVersion(), file_->GetWidth(), file_->GetHeight(), file_->GetDepth(),
 		file_->GetFrameCount(), file_->GetMipmapCount(), file_->GetFaceCount(),
 		ImageFormatToString(file_->GetFormat()));
+	if (file_->GetMajorVersion() >= 7 && file_->GetMinorVersion() >= 6)
+		fmt::print(FMT_STRING(", DEFLATE compression level {}\n"), file_->GetAuxCompressionLevel());
+	else
+		std::cout << "\n";
 }

--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -348,3 +348,15 @@ const char* imglib::image_get_extension(FileFormat format) {
 			return "";
 	}
 }
+
+VTFImageFormat imglib::get_vtf_format(const ImageInfo_t& info) {
+	switch (info.type) {
+		case imglib::UInt16:
+			// @TODO: How to handle RGBA16? DONT i guess
+			return IMAGE_FORMAT_RGBA16161616F;
+		case imglib::Float:
+			return (info.comps == 3) ? IMAGE_FORMAT_RGB323232F : IMAGE_FORMAT_RGBA32323232F;
+		default:
+			return (info.comps == 3) ? IMAGE_FORMAT_RGB888 : IMAGE_FORMAT_RGBA8888;
+	}
+}

--- a/src/common/image.hpp
+++ b/src/common/image.hpp
@@ -6,6 +6,8 @@
 #include <filesystem>
 #include <string>
 
+#include "VTFLib.h"
+
 namespace imglib
 {
 
@@ -126,5 +128,10 @@ namespace imglib
 	void convert_rgba32_rgba16(const void* rgba32, void* rgba16, int w, int h);
 	void convert_rgb8_rgb16(const void* rgb8, void* rgb16, int w, int h);
 	void convert_rgba8_rgba16(const void* rgba8, void* rgba16, int w, int h);
+
+	/**
+	 * Get a compatible VTF image format for the image data
+	 */
+	VTFImageFormat get_vtf_format(const ImageInfo_t& info);
 
 } // namespace imglib

--- a/src/common/util.hpp
+++ b/src/common/util.hpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <string>
 #include <memory>
+#include <charconv>
 
 #include "strtools.hpp"
 
@@ -34,6 +35,11 @@ namespace util
 		stream.read((char*)outPtr, size);
 
 		return size;
+	}
+
+	static inline bool strtoint(const std::string& str, int& out) {
+		auto [p, err] = std::from_chars(str.c_str(), str.c_str() + str.length(), out);
+		return err == std::errc();
 	}
 
 	/**

--- a/src/gui/viewer.cpp
+++ b/src/gui/viewer.cpp
@@ -120,7 +120,7 @@ void ViewerMainWindow::setup_ui() {
 
 	// Register global actions
 	shortcuts_.resize(Action_Count);
-	auto* saveShortcut = new QShortcut(
+	shortcuts_[Actions::Save] = new QShortcut(
 		QKeySequence::Save, this,
 		[this]
 		{
@@ -411,22 +411,9 @@ void ViewerMainWindow::import_file() {
 		return;
 	}
 
-	VTFImageFormat format;
-	switch (data.info.type) {
-		case imglib::UInt16:
-			format = IMAGE_FORMAT_RGBA16161616F;
-			break; // @TODO: Add RGBA16 support
-		case imglib::Float:
-			format = (data.info.comps == 3) ? IMAGE_FORMAT_RGB323232F : IMAGE_FORMAT_RGBA32323232F;
-			break;
-		default:
-			format = (data.info.comps == 3) ? IMAGE_FORMAT_RGB888 : IMAGE_FORMAT_RGBA8888;
-			break;
-	}
-
 	auto file = new CVTFFile();
 
-	file->Create(data.info.w, data.info.h, 1, 1, 1, format);
+	file->Create(data.info.w, data.info.h, 1, 1, 1, imglib::get_vtf_format(data.info));
 	file->SetData(1, 1, 1, 0, (vlByte*)data.data);
 
 	document()->load_file(file);


### PR DESCRIPTION
* Adds `-c`/`--compress` to the convert action
* Adds compression level info to `vtex2 info`
* Fix options being added twice to `convert` (wtf did I do)
* Improve documentation


Also requires this to be merged: https://github.com/ChaosInitiative/VTFLib/pull/4