### PR TITLE
feat: Add support for bc4,5,7 formats

### DIFF
--- a/src/cli/action_convert.cpp
+++ b/src/cli/action_convert.cpp
@@ -94,6 +94,7 @@ const OptionList& ActionConvert::get_options() const {
 					"rgba32323232f",
 					"ati2n",
 					"ati1n",
+					"bc7",
 				})
 				.help("Image format of the VTF"));
 
@@ -253,8 +254,9 @@ bool ActionConvert::process_file(
 	std::filesystem::path outFile;
 	if (userOutputFile.empty()) {
 		outFile = srcFile.parent_path() / srcFile.filename().replace_extension(".vtf");
-	} else {
-		outFile = srcFile.parent_path()  / userOutputFile;
+	}
+	else {
+		outFile = srcFile.parent_path() / userOutputFile;
 	}
 
 	auto format = ImageFormatFromUserString(formatStr.c_str());

--- a/src/common/enums.cpp
+++ b/src/common/enums.cpp
@@ -68,24 +68,14 @@ const char* ImageFormatToString(VTFImageFormat format) {
 			return "IMAGE_FORMAT_RGB323232F";
 		case IMAGE_FORMAT_RGBA32323232F:
 			return "IMAGE_FORMAT_RGBA32323232F";
-		case IMAGE_FORMAT_NV_DST16:
-			return "IMAGE_FORMAT_NV_DST16";
-		case IMAGE_FORMAT_NV_DST24:
-			return "IMAGE_FORMAT_NV_DST24";
-		case IMAGE_FORMAT_NV_INTZ:
-			return "IMAGE_FORMAT_NV_INTZ";
-		case IMAGE_FORMAT_NV_RAWZ:
-			return "IMAGE_FORMAT_NV_RAWZ";
-		case IMAGE_FORMAT_ATI_DST16:
-			return "IMAGE_FORMAT_ATI_DST16";
-		case IMAGE_FORMAT_ATI_DST24:
-			return "IMAGE_FORMAT_ATI_DST24";
 		case IMAGE_FORMAT_NV_NULL:
 			return "IMAGE_FORMAT_NV_NULL";
 		case IMAGE_FORMAT_ATI2N:
 			return "IMAGE_FORMAT_ATI2N";
 		case IMAGE_FORMAT_ATI1N:
 			return "IMAGE_FORMAT_ATI1N";
+		case IMAGE_FORMAT_BC7:
+			return "IMAGE_FORMAT_BC7";
 		case IMAGE_FORMAT_COUNT:
 			return "IMAGE_FORMAT_COUNT";
 		case IMAGE_FORMAT_NONE:
@@ -156,24 +146,14 @@ VTFImageFormat ImageFormatFromString(const char* arg) {
 		return IMAGE_FORMAT_RGB323232F;
 	else if (str::strcasecmp("IMAGE_FORMAT_RGBA32323232F", arg) == 0)
 		return IMAGE_FORMAT_RGBA32323232F;
-	else if (str::strcasecmp("IMAGE_FORMAT_NV_DST16", arg) == 0)
-		return IMAGE_FORMAT_NV_DST16;
-	else if (str::strcasecmp("IMAGE_FORMAT_NV_DST24", arg) == 0)
-		return IMAGE_FORMAT_NV_DST24;
-	else if (str::strcasecmp("IMAGE_FORMAT_NV_INTZ", arg) == 0)
-		return IMAGE_FORMAT_NV_INTZ;
-	else if (str::strcasecmp("IMAGE_FORMAT_NV_RAWZ", arg) == 0)
-		return IMAGE_FORMAT_NV_RAWZ;
-	else if (str::strcasecmp("IMAGE_FORMAT_ATI_DST16", arg) == 0)
-		return IMAGE_FORMAT_ATI_DST16;
-	else if (str::strcasecmp("IMAGE_FORMAT_ATI_DST24", arg) == 0)
-		return IMAGE_FORMAT_ATI_DST24;
 	else if (str::strcasecmp("IMAGE_FORMAT_NV_NULL", arg) == 0)
 		return IMAGE_FORMAT_NV_NULL;
 	else if (str::strcasecmp("IMAGE_FORMAT_ATI2N", arg) == 0)
 		return IMAGE_FORMAT_ATI2N;
 	else if (str::strcasecmp("IMAGE_FORMAT_ATI1N", arg) == 0)
 		return IMAGE_FORMAT_ATI1N;
+	else if (str::strcasecmp("IMAGE_FORMAT_BC7", arg) == 0)
+		return IMAGE_FORMAT_BC7;
 	else if (str::strcasecmp("IMAGE_FORMAT_COUNT", arg) == 0)
 		return IMAGE_FORMAT_COUNT;
 	else
@@ -346,24 +326,14 @@ VTFImageFormat ImageFormatFromUserString(const char* arg) {
 		return IMAGE_FORMAT_RGB323232F;
 	else if (str::strcasecmp("RGBA32323232F", arg) == 0)
 		return IMAGE_FORMAT_RGBA32323232F;
-	else if (str::strcasecmp("NV_DST16", arg) == 0)
-		return IMAGE_FORMAT_NV_DST16;
-	else if (str::strcasecmp("NV_DST24", arg) == 0)
-		return IMAGE_FORMAT_NV_DST24;
-	else if (str::strcasecmp("NV_INTZ", arg) == 0)
-		return IMAGE_FORMAT_NV_INTZ;
-	else if (str::strcasecmp("NV_RAWZ", arg) == 0)
-		return IMAGE_FORMAT_NV_RAWZ;
-	else if (str::strcasecmp("ATI_DST16", arg) == 0)
-		return IMAGE_FORMAT_ATI_DST16;
-	else if (str::strcasecmp("ATI_DST24", arg) == 0)
-		return IMAGE_FORMAT_ATI_DST24;
 	else if (str::strcasecmp("NV_NULL", arg) == 0)
 		return IMAGE_FORMAT_NV_NULL;
 	else if (str::strcasecmp("ATI2N", arg) == 0)
 		return IMAGE_FORMAT_ATI2N;
 	else if (str::strcasecmp("ATI1N", arg) == 0)
 		return IMAGE_FORMAT_ATI1N;
+	else if (str::strcasecmp("BC7", arg) == 0)
+		return IMAGE_FORMAT_BC7;
 	else if (str::strcasecmp("COUNT", arg) == 0)
 		return IMAGE_FORMAT_COUNT;
 	else

--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -15,7 +15,7 @@
 using namespace imglib;
 
 FILE* imglib::image_begin(const char* filePath) {
-	return fopen(filePath, "r");
+	return fopen(filePath, "rb");
 }
 
 ImageInfo_t imglib::image_info(FILE* fp) {

--- a/src/gui/viewer.cpp
+++ b/src/gui/viewer.cpp
@@ -468,6 +468,7 @@ static inline constexpr struct {
 	{IMAGE_FORMAT_RGBA32323232F, "RGBA32323232F"},
 	{IMAGE_FORMAT_ATI2N, "ATI2N"},
 	{IMAGE_FORMAT_ATI1N, "ATI1N"},
+	{IMAGE_FORMAT_BC7, "BC7"},
 };
 
 InfoWidget::InfoWidget(Document* doc, QWidget* pParent)


### PR DESCRIPTION
Allows BC4, BC5, and BC7 to be used in the convert command to create VTFs of those formats.

Also fixes some crashes/bugs in the convert command / image library.